### PR TITLE
split by other whitespace characters

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -192,6 +192,10 @@ func registerCallbacks(collector *colly.Collector, config *skweezConf, cache *ma
 	})
 }
 
+func Split(r rune) bool {
+	return r == ' ' || r == '\n' || r == '\r'
+}
+
 // cache should be a param, too. Allows for better testability
 func extractWords(body []byte, config *skweezConf, cache *map[string]int) {
 	domDoc := html.NewTokenizer(strings.NewReader(string(body)))
@@ -210,7 +214,7 @@ outer:
 			}
 			TxtContent := strings.TrimSpace(html.UnescapeString(string(domDoc.Text())))
 			if len(TxtContent) > 0 {
-				unfilteredWords := strings.Split(TxtContent, " ")
+				unfilteredWords := strings.FieldsFunc(TxtContent, Split)
 				var filteredWords []string
 				for _, word := range unfilteredWords {
 					candidate := strings.Trim(word, stripTrailingSymbols)


### PR DESCRIPTION
I noticed that the split function doesn't work correct if the webserver contains plain text file. This patch adds more white space characters fix that issue